### PR TITLE
Depend on iproute2

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -91,7 +91,7 @@ Depends:
  grub-common,
  host,
  ipmitool,
- iproute,
+ iproute2,
  iputils-arping,
  isc-dhcp-client,
  kbd (>= 1.12-14),


### PR DESCRIPTION
iproute is just a dummy transitional package, and is actually removed in Debian bullseye, so just depend on the transitive real dependency.
See: https://github.com/danos/iproute2/blob/master/debian/control#L50